### PR TITLE
Add entries table to weight tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,19 @@
   <h2>Evolución del peso</h2>
   <canvas id="chart" width="400" height="200"></canvas>
 
+  <h2>Registros</h2>
+  <table id="entries-table">
+    <thead>
+      <tr>
+        <th>Fecha</th>
+        <th>Peso (kg)</th>
+        <th>Cintura (cm)</th>
+        <th>Pecho (cm)</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
   <script src="script.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/script.js
+++ b/script.js
@@ -14,6 +14,33 @@ const chart = new Chart(ctx, {
   }
 });
 
+const tableBody = document.querySelector('#entries-table tbody');
+
+const formatValue = value => Number.isFinite(value) ? value.toString() : '-';
+
+function renderTable() {
+  if (!tableBody) {
+    return;
+  }
+  tableBody.innerHTML = '';
+  data.forEach(entry => {
+    const row = document.createElement('tr');
+    const weight = Number.isFinite(entry.weight) ? entry.weight : null;
+    const waist = Number.isFinite(entry.waist) ? entry.waist : null;
+    const chest = Number.isFinite(entry.chest) ? entry.chest : null;
+
+    row.innerHTML = `
+      <td>${entry.date}</td>
+      <td>${formatValue(weight)}</td>
+      <td>${formatValue(waist)}</td>
+      <td>${formatValue(chest)}</td>
+    `;
+    tableBody.appendChild(row);
+  });
+}
+
+renderTable();
+
 document.getElementById("form").addEventListener("submit", e => {
   e.preventDefault();
   const date = document.getElementById("date").value;
@@ -27,6 +54,8 @@ document.getElementById("form").addEventListener("submit", e => {
   chart.data.labels.push(date);
   chart.data.datasets[0].data.push(weight);
   chart.update();
+
+  renderTable();
 
   e.target.reset();
 });

--- a/style.css
+++ b/style.css
@@ -13,3 +13,19 @@ input, button {
 canvas {
   max-width: 100%;
 }
+
+table {
+  margin: 20px auto;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 600px;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 8px;
+}
+
+th {
+  background-color: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- add a records table to list stored weight, waist, and chest measurements
- render table contents from local storage and refresh them whenever a new entry is saved
- style the table for readability alongside the existing chart

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd9cc18a7c83279b0642a4f82bf6a4