### PR TITLE
Ensure table rows include edit and delete buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -563,44 +563,67 @@ function renderTable(list) {
   const fragment = document.createDocumentFragment();
 
   for (const entry of list) {
-    const row = document.createElement("tr");
-    row.dataset.entryId = entry.id;
-    row.dataset.date = entry.date;
-    row.setAttribute("aria-selected", "false");
-    const displayDate = formatTableDate(entry.date);
-    row.innerHTML = `
-      <td>${displayDate}</td>
-      <td>${formatMetric(entry.weight, "kg")}</td>
-      <td>${formatOptionalMetric(entry.waist, "cm")}</td>
-      <td>${formatOptionalMetric(entry.chest, "cm")}</td>
-    `;
-    const actionsCell = document.createElement("td");
-    actionsCell.className = "table-actions-cell";
-    const actions = document.createElement("div");
-    actions.className = "table-actions";
-    const friendlyDate = displayDate;
-    const editButton = createTableActionButton(
-      "edit",
-      entry.id,
-      "✏️",
-      "Editar",
-      `Editar registro del ${friendlyDate}`,
-    );
-    const deleteButton = createTableActionButton(
-      "delete",
-      entry.id,
-      "🗑️",
-      "Eliminar",
-      `Eliminar registro del ${friendlyDate}`,
-    );
-    deleteButton.classList.add("danger");
-    actions.append(editButton, deleteButton);
-    actionsCell.appendChild(actions);
-    row.appendChild(actionsCell);
+    const row = createTableRow(entry);
     fragment.appendChild(row);
   }
 
   body.appendChild(fragment);
+}
+
+function createTableRow(entry) {
+  const row = document.createElement("tr");
+  row.dataset.entryId = entry.id;
+  row.dataset.date = entry.date;
+  row.setAttribute("aria-selected", "false");
+
+  const displayDate = formatTableDate(entry.date);
+  const friendlyDate = displayDate;
+
+  const dateCell = createTableCell(displayDate);
+  const weightCell = createTableCell(formatMetric(entry.weight, "kg"));
+  const waistCell = createTableCell(formatOptionalMetric(entry.waist, "cm"));
+  const chestCell = createTableCell(formatOptionalMetric(entry.chest, "cm"));
+  const actionsCell = createTableActionsCell(entry.id, friendlyDate);
+
+  row.append(dateCell, weightCell, waistCell, chestCell, actionsCell);
+  return row;
+}
+
+function createTableCell(content, className) {
+  const cell = document.createElement("td");
+  if (className) {
+    cell.className = className;
+  }
+  cell.textContent = content;
+  return cell;
+}
+
+function createTableActionsCell(entryId, friendlyDate) {
+  const cell = document.createElement("td");
+  cell.className = "table-actions-cell";
+
+  const actions = document.createElement("div");
+  actions.className = "table-actions";
+
+  const editButton = createTableActionButton(
+    "edit",
+    entryId,
+    "✏️",
+    "Editar",
+    `Editar registro del ${friendlyDate}`,
+  );
+  const deleteButton = createTableActionButton(
+    "delete",
+    entryId,
+    "🗑️",
+    "Eliminar",
+    `Eliminar registro del ${friendlyDate}`,
+  );
+  deleteButton.classList.add("danger");
+
+  actions.append(editButton, deleteButton);
+  cell.appendChild(actions);
+  return cell;
 }
 
 function createTableActionButton(action, entryId, icon, label, ariaLabel) {
@@ -624,60 +647,6 @@ function createTableActionButton(action, entryId, icon, label, ariaLabel) {
 
   button.append(iconSpan, labelSpan);
   return button;
-}
-
-function formatOptionalMetric(value, unit) {
-  if (value === null || value === undefined) {
-    return "—";
-  }
-  return formatMetric(value, unit);
-}
-
-function formatMetric(value, unit) {
-  const numericValue = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(numericValue)) {
-    return `${value} ${unit}`;
-  }
-  return `${numberFormatter.format(numericValue)} ${unit}`;
-}
-
-function formatTableDate(isoDate) {
-  const parsed = parseIsoDate(isoDate);
-  if (!parsed) {
-    return isoDate;
-  }
-  return tableDateFormatter.format(parsed);
-}
-
-function renderTable(list) {
-  const body = elements.tableBody;
-  const emptyState = elements.tableEmptyState;
-  if (!body || !emptyState) {
-    return;
-  }
-
-  body.textContent = "";
-
-  if (!list.length) {
-    emptyState.classList.add("is-visible");
-    return;
-  }
-
-  emptyState.classList.remove("is-visible");
-  const fragment = document.createDocumentFragment();
-
-  for (const entry of list) {
-    const row = document.createElement("tr");
-    row.innerHTML = `
-      <td>${formatTableDate(entry.date)}</td>
-      <td>${formatMetric(entry.weight, "kg")}</td>
-      <td>${formatOptionalMetric(entry.waist, "cm")}</td>
-      <td>${formatOptionalMetric(entry.chest, "cm")}</td>
-    `;
-    fragment.appendChild(row);
-  }
-
-  body.appendChild(fragment);
 }
 
 function formatOptionalMetric(value, unit) {


### PR DESCRIPTION
## Summary
- render each history row through a helper that builds the full set of table cells
- add dedicated helpers to create the text and action cells with their buttons

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68cdba4682c48327a6a64f6b0cddd86b