### PR TITLE
Add table row template with action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,26 @@
           </thead>
           <tbody id="entries-table-body"></tbody>
         </table>
+        <template id="entry-row-template">
+          <tr data-entry-id="" data-date="" aria-selected="false">
+            <td class="table-cell table-cell-date"></td>
+            <td class="table-cell table-cell-weight"></td>
+            <td class="table-cell table-cell-waist"></td>
+            <td class="table-cell table-cell-chest"></td>
+            <td class="table-actions-cell">
+              <div class="table-actions">
+                <button type="button" class="table-action with-icon" data-action="edit">
+                  <span class="button-icon" aria-hidden="true">✏️</span>
+                  <span>Editar</span>
+                </button>
+                <button type="button" class="table-action with-icon danger" data-action="delete">
+                  <span class="button-icon" aria-hidden="true">🗑️</span>
+                  <span>Eliminar</span>
+                </button>
+              </div>
+            </td>
+          </tr>
+        </template>
         <p id="entries-empty-state" class="table-empty" role="status" aria-hidden="true">Todavía no hay registros guardados.</p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- define an HTML template for history rows that already contains the edit and delete buttons
- update the table rendering logic to clone the template, wiring up labels and dataset attributes, with a fallback for older markup

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68cdba4682c48327a6a64f6b0cddd86b