### PR TITLE
Switch app shell assets to network-first caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -34,6 +34,11 @@ self.addEventListener("fetch", event => {
     return;
   }
 
+  if (APP_SHELL.includes(requestUrl.toString())) {
+    event.respondWith(networkFirstAsset(event.request));
+    return;
+  }
+
   event.respondWith(cacheFirst(event.request));
 });
 
@@ -68,6 +73,23 @@ async function networkFirst(request) {
     if (cachedIndex) {
       return cachedIndex;
     }
+    const cachedResponse = await cache.match(request, { ignoreSearch: true });
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+    throw error;
+  }
+}
+
+async function networkFirstAsset(request) {
+  const cache = await caches.open(CACHE_NAME);
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
     const cachedResponse = await cache.match(request, { ignoreSearch: true });
     if (cachedResponse) {
       return cachedResponse;


### PR DESCRIPTION
## Summary
- update the fetch handler to serve app shell files with a network-first strategy
- add a dedicated helper so static assets update the cache after successful fetches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc33df8b4832798d24a255e6b88fe