### PR TITLE
Adjust form layout breakpoint for figure alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,7 +126,7 @@ form {
   list-style: disc;
 }
 
-@media (min-width: 960px) {
+@media (min-width: 720px) {
   .form-layout {
     flex-direction: row;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- reduce the breakpoint for the form layout so the measurement figure sits beside the form on medium screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce56210c148327a74ff8526a61621a