### PR TITLE
Fix truncated labels in body diagram

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,6 +107,7 @@ form {
   width: 100%;
   max-width: 320px;
   align-self: center;
+  overflow: visible;
 }
 
 .measurement-figure figcaption {


### PR DESCRIPTION
## Summary
- allow the measurement diagram SVG to render overflowing content so labels are no longer clipped

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce575bbd4083279c7f0f90f47f475b