### PR TITLE
Add Excel export for history table

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,10 @@
     <section class="card">
       <header class="section-header">
         <h2>Historial de registros</h2>
+        <button type="button" id="export-excel" class="ghost with-icon">
+          <span class="button-icon" aria-hidden="true">⬇️</span>
+          <span>Descargar Excel</span>
+        </button>
       </header>
       <div class="table-wrapper">
         <table id="entries-table">


### PR DESCRIPTION
## Summary
- add a "Descargar Excel" button to the history section
- implement client-side Excel export for stored entries using a dynamic SheetJS import
- disable the export action when there are no records available

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce9e5f94688327ab91fa47dfc939f6